### PR TITLE
PLATUI-3434 check for fnm and install node if needed

### DIFF
--- a/start_prototype.sh
+++ b/start_prototype.sh
@@ -6,6 +6,15 @@
 TEMP_FOLDER="tmp-test-script"
 REPO="example-ui-journey-tests-prototype"
 
+if command -V fnm; then
+    eval "$(fnm env)"
+    export FNM_NODE_DIST_MIRROR=https://artefacts.tax.service.gov.uk/artifactory/nodejs/dist
+    fnm install --lts
+    if [[ -n "${ARTIFACTORY_URI}" ]]; then
+        npm config set registry=\${ARTIFACTORY_URI}/api/npm/npmjs
+    fi
+fi 
+
 mkdir $TEMP_FOLDER
 cd $TEMP_FOLDER
 git clone https://github.com/hmrc/$REPO


### PR DESCRIPTION
# Purpose of PR
- Check if `fnm` is installed and if so, install node.
  - This is because our build jobs now don't use npm by default, rather it uses fnm. We can install node via fnm.
- Also do a check for if the `ARTIFACTORY_URI` env var is set and if so, update node accordingly